### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,5 +1,8 @@
 name: Publish to Winget
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/WindowsTerminal/security/code-scanning/1](https://github.com/Git-Hub-Chris/WindowsTerminal/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it primarily interacts with release assets and uses a secret to publish to Winget. Therefore, the `contents: read` permission is sufficient for accessing release assets, and no additional write permissions are required. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
